### PR TITLE
:FC-776: :sparkles: Invocations by Skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveperson-functions-client",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "JavaScript client for LivePerson Functions.",
   "author": {
     "name": "LivePersonInc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveperson-functions-client",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "JavaScript client for LivePerson Functions.",
   "author": {
     "name": "LivePersonInc",

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -132,8 +132,10 @@ export class BaseClient {
     baseMetrics.event = isImplementedRequestData.eventId;
     const watch = new stopwatch();
     watch.start();
-    const cachedEvent: ImplementedEvent | undefined =
-      this.tooling.isImplementedCache.get(isImplementedRequestData.eventId);
+    const cachedEvent: ImplementedEvent
+      | undefined = this.tooling.isImplementedCache.get(
+      isImplementedRequestData.eventId
+    );
     if (cachedEvent !== undefined) {
       const successFromCacheMetric = this.enhanceBaseMetrics(baseMetrics, {
         fromCache: true,

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -135,7 +135,8 @@ export class BaseClient {
     const cachedEvent:
       | ImplementedEvent
       | undefined = this.tooling.isImplementedCache.get(
-      isImplementedRequestData.eventId
+      isImplementedRequestData.eventId,
+      isImplementedRequestData.skillId
     );
     if (cachedEvent !== undefined) {
       const successFromCacheMetric = this.enhanceBaseMetrics(baseMetrics, {

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -132,7 +132,8 @@ export class BaseClient {
     baseMetrics.event = isImplementedRequestData.eventId;
     const watch = new stopwatch();
     watch.start();
-    const cachedEvent: ImplementedEvent
+    const cachedEvent:
+      | ImplementedEvent
       | undefined = this.tooling.isImplementedCache.get(
       isImplementedRequestData.eventId
     );

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -281,6 +281,7 @@ export class BaseClient {
       );
       const query: BaseQuery = {
         v: isImplementedData.apiVersion,
+        skillId: isImplementedData.skillId,
         externalSystem: isImplementedData.externalSystem,
       };
       const url = await this.getUrl({

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -132,11 +132,8 @@ export class BaseClient {
     baseMetrics.event = isImplementedRequestData.eventId;
     const watch = new stopwatch();
     watch.start();
-    const cachedEvent:
-      | ImplementedEvent
-      | undefined = this.tooling.isImplementedCache.get(
-      isImplementedRequestData.eventId
-    );
+    const cachedEvent: ImplementedEvent | undefined =
+      this.tooling.isImplementedCache.get(isImplementedRequestData.eventId);
     if (cachedEvent !== undefined) {
       const successFromCacheMetric = this.enhanceBaseMetrics(baseMetrics, {
         fromCache: true,
@@ -160,7 +157,8 @@ export class BaseClient {
         this.tooling.metricCollector?.onIsImplemented(successMetric);
         this.tooling.isImplementedCache.add(
           isImplementedRequestData.eventId,
-          implemented
+          implemented,
+          isImplementedRequestData.skillId
         );
         return implemented;
       } catch (error) {
@@ -293,12 +291,10 @@ export class BaseClient {
       });
       const {
         body: {implemented},
-      }: Response = (await this.doFetch({
+      }: Response = await this.doFetch({
         url,
         ...isImplementedData,
-      })) || {
-        body: {},
-      };
+      });
       if (implemented === undefined) {
         throw new VError(
           {

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -482,6 +482,7 @@ export class BaseClient {
       domain: 'unresolved',
       fromCache: false,
       externalSystem: data?.externalSystem,
+      skillId: data?.skillId,
     };
   }
 

--- a/src/helper/isImplementedCache.ts
+++ b/src/helper/isImplementedCache.ts
@@ -11,16 +11,11 @@ export class IsImplementedCache {
   constructor(private cacheDuration: number) {}
 
   get(eventName: string, skillId?: string): ImplementedEvent | undefined {
-    let event: ImplementedEvent | undefined;
-    if (skillId) {
-      event = this.cache.find(e => {
-        return e.name === eventName && e.skillId === skillId;
-      });
-    } else {
-      event = this.cache.find(e => {
-        return e.name === eventName;
-      });
-    }
+    const event: ImplementedEvent | undefined = this.cache.find(e => {
+      return skillId
+        ? e.name === eventName && e.skillId === skillId
+        : e.name === eventName;
+    });
     if (event) {
       if (event.exp > Date.now()) return event;
       this.removeFromCache(event);

--- a/src/helper/isImplementedCache.ts
+++ b/src/helper/isImplementedCache.ts
@@ -2,6 +2,7 @@ export interface ImplementedEvent {
   name: string;
   exp: number;
   isImplemented: boolean;
+  skillId?: string;
 }
 
 export class IsImplementedCache {
@@ -20,7 +21,7 @@ export class IsImplementedCache {
     return undefined;
   }
 
-  add(eventName: string, isImplemented: boolean): void {
+  add(eventName: string, isImplemented: boolean, skillId?: string): void {
     const event: ImplementedEvent | undefined = this.get(eventName);
     if (event) {
       this.removeFromCache(event);
@@ -29,6 +30,7 @@ export class IsImplementedCache {
       name: eventName,
       exp: Date.now() + this.cacheDuration * 1000,
       isImplemented,
+      skillId,
     };
     this.cache.push(newEvent);
   }

--- a/src/helper/isImplementedCache.ts
+++ b/src/helper/isImplementedCache.ts
@@ -10,10 +10,17 @@ export class IsImplementedCache {
 
   constructor(private cacheDuration: number) {}
 
-  get(eventName: string): ImplementedEvent | undefined {
-    const event: ImplementedEvent | undefined = this.cache.find(e => {
-      return e.name === eventName;
-    });
+  get(eventName: string, skillId?: string): ImplementedEvent | undefined {
+    let event: ImplementedEvent | undefined;
+    if (skillId) {
+      event = this.cache.find(e => {
+        return e.name === eventName && e.skillId === skillId;
+      });
+    } else {
+      event = this.cache.find(e => {
+        return e.name === eventName;
+      });
+    }
     if (event) {
       if (event.exp > Date.now()) return event;
       this.removeFromCache(event);
@@ -22,7 +29,7 @@ export class IsImplementedCache {
   }
 
   add(eventName: string, isImplemented: boolean, skillId?: string): void {
-    const event: ImplementedEvent | undefined = this.get(eventName);
+    const event: ImplementedEvent | undefined = this.get(eventName, skillId);
     if (event) {
       this.removeFromCache(event);
     }

--- a/src/helper/metricCollector.ts
+++ b/src/helper/metricCollector.ts
@@ -9,6 +9,7 @@ export interface InvocationMetricData {
   statusCode?: number;
   error?: Error;
   fromCache?: boolean;
+  skillId?: string;
 }
 export interface MetricCollector {
   onInvoke(invocationData: InvocationMetricData): void;

--- a/src/types/invocationTypes.ts
+++ b/src/types/invocationTypes.ts
@@ -7,6 +7,7 @@ export interface BaseInvocation extends Partial<BaseConfig> {
   readonly externalSystem: string;
   readonly apiVersion?: string;
   readonly userId?: string;
+  readonly skillId?: string;
 }
 
 export interface BasePostInvocation extends BaseInvocation {

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -1,6 +1,7 @@
 export interface BaseQuery {
   readonly v: string;
   readonly externalSystem: string;
+  readonly skillId?: string;
 }
 
 export interface GetLambdasQuery extends Partial<BaseQuery> {

--- a/test/isImplementedCache.test.ts
+++ b/test/isImplementedCache.test.ts
@@ -33,9 +33,14 @@ describe('ImplementedCache', () => {
     it('should return an event that has skillId', () => {
       isImplementedCache.add(event, true, 'smapleSkill');
 
-      expect(isImplementedCache.get(event)).toBeDefined();
-      expect(isImplementedCache.get(event)?.skillId).toBeDefined();
-      expect(isImplementedCache.get(event)?.skillId).toBeString();
+      expect(isImplementedCache.get(event,'smapleSkill')).toBeDefined();
+      expect(isImplementedCache.get(event,'smapleSkill')?.skillId).toBeDefined();
+      expect(isImplementedCache.get(event,'smapleSkill')?.skillId).toBeString();
+    });
+    it('should not return an event when filtering by wrong skillId', () => {
+      isImplementedCache.add(event, true,'skill');
+
+      expect(isImplementedCache.get(event,'skillsample')).toBeUndefined();
     });
   });
   // No unhappy flows since cache does not throw any errors

--- a/test/isImplementedCache.test.ts
+++ b/test/isImplementedCache.test.ts
@@ -14,15 +14,15 @@ describe('ImplementedCache', () => {
         isImplementedCache.add(event, true);
 
         expect(isImplementedCache.get(event)).toBeDefined();
-        expect(isImplementedCache.get(event)?.isImplemented).toBe(true);
+        expect(isImplementedCache.get(event)?.isImplemented).toBeTrue();
       }
     );
     it('should overwrite a specific event that already exists in cache', () => {
       isImplementedCache.add(event, true);
-      isImplementedCache.add(event, true);
+      isImplementedCache.add(event, false);
 
       expect(isImplementedCache.get(event)).toBeDefined();
-      expect(isImplementedCache.get(event)?.isImplemented).toBe(false);
+      expect(isImplementedCache.get(event)?.isImplemented).toBeFalse();
     });
     it('should not return an event that is expired', () => {
       isImplementedCache = new IsImplementedCache(-2);
@@ -35,6 +35,7 @@ describe('ImplementedCache', () => {
 
       expect(isImplementedCache.get(event)).toBeDefined();
       expect(isImplementedCache.get(event)?.skillId).toBeDefined();
+      expect(isImplementedCache.get(event)?.skillId).toBeString();
     });
   });
   // No unhappy flows since cache does not throw any errors

--- a/test/isImplementedCache.test.ts
+++ b/test/isImplementedCache.test.ts
@@ -30,14 +30,14 @@ describe('ImplementedCache', () => {
 
       expect(isImplementedCache.get(event)).toBeUndefined();
     });
-    it('should return an event that has skillId', () => {
+    it('should return the event with the provided skillId', () => {
       isImplementedCache.add(event, true, 'sampleSkill');
 
       expect(isImplementedCache.get(event,'sampleSkill')).toBeDefined();
       expect(isImplementedCache.get(event,'sampleSkill')?.skillId).toBeString();
       expect(isImplementedCache.get(event,'sampleSkill')?.skillId).toEqual('sampleSkill');
     });
-    it('should not return an event when filtering by wrong skillId', () => {
+    it('hould not return an undefined if no entry for provided skillId was found', () => {
       isImplementedCache.add(event, true,'skill');
 
       expect(isImplementedCache.get(event,'skillsample')).toBeUndefined();

--- a/test/isImplementedCache.test.ts
+++ b/test/isImplementedCache.test.ts
@@ -31,11 +31,11 @@ describe('ImplementedCache', () => {
       expect(isImplementedCache.get(event)).toBeUndefined();
     });
     it('should return an event that has skillId', () => {
-      isImplementedCache.add(event, true, 'smapleSkill');
+      isImplementedCache.add(event, true, 'sampleSkill');
 
-      expect(isImplementedCache.get(event,'smapleSkill')).toBeDefined();
-      expect(isImplementedCache.get(event,'smapleSkill')?.skillId).toBeDefined();
-      expect(isImplementedCache.get(event,'smapleSkill')?.skillId).toBeString();
+      expect(isImplementedCache.get(event,'sampleSkill')).toBeDefined();
+      expect(isImplementedCache.get(event,'sampleSkill')?.skillId).toBeString();
+      expect(isImplementedCache.get(event,'sampleSkill')?.skillId).toEqual('sampleSkill');
     });
     it('should not return an event when filtering by wrong skillId', () => {
       isImplementedCache.add(event, true,'skill');

--- a/test/isImplementedCache.test.ts
+++ b/test/isImplementedCache.test.ts
@@ -14,21 +14,27 @@ describe('ImplementedCache', () => {
         isImplementedCache.add(event, true);
 
         expect(isImplementedCache.get(event)).toBeDefined();
-        expect(isImplementedCache.get(event)?.isImplemented).toBeTrue();
+        expect(isImplementedCache.get(event)?.isImplemented).toBe(true);
       }
     );
     it('should overwrite a specific event that already exists in cache', () => {
       isImplementedCache.add(event, true);
-      isImplementedCache.add(event, false);
+      isImplementedCache.add(event, true);
 
       expect(isImplementedCache.get(event)).toBeDefined();
-      expect(isImplementedCache.get(event)?.isImplemented).toBeFalse();
+      expect(isImplementedCache.get(event)?.isImplemented).toBe(false);
     });
     it('should not return an event that is expired', () => {
       isImplementedCache = new IsImplementedCache(-2);
       isImplementedCache.add(event, true);
 
       expect(isImplementedCache.get(event)).toBeUndefined();
+    });
+    it('should return an event that has skillId', () => {
+      isImplementedCache.add(event, true, 'smapleSkill');
+
+      expect(isImplementedCache.get(event)).toBeDefined();
+      expect(isImplementedCache.get(event)?.skillId).toBeDefined();
     });
   });
   // No unhappy flows since cache does not throw any errors

--- a/test/unit/base_client.test.ts
+++ b/test/unit/base_client.test.ts
@@ -293,6 +293,53 @@ describe('Base Client', () => {
       );
     });
 
+    test('isImplemented with skillId', async () => {
+      expect.hasAssertions();
+      const client = new BaseClient(testConfig, testTooling);
+      const hasBeenImplemented = await client.isImplemented({
+        eventId: EVENT.MessagingNewConversation,
+        externalSystem: 'test',
+        skillId: 'skill'
+      });
+      expect(testTooling.metricCollector.onIsImplemented).toHaveBeenCalledTimes(
+        1
+      );
+      expect(testTooling.metricCollector.onIsImplemented).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: testConfig.accountId,
+          event: EVENT.MessagingNewConversation,
+          skillId: 'skill',
+          externalSystem: 'test',
+          domain: 'test-domain.com',
+          fromCache: false,
+        })
+      );
+      expect(hasBeenImplemented).toBeTrue();
+      expect(testTooling.generateId).toHaveBeenCalledTimes(1);
+      expect(testTooling.getCsdsEntry).toHaveBeenCalledTimes(1);
+      expect(testTooling.fetch).toHaveBeenCalledTimes(1);
+      const hasBeenImplementedAgain = await client.isImplemented({
+        eventId: EVENT.MessagingNewConversation,
+        externalSystem: 'test',
+        skillId: 'skill'
+      });
+      // should still only have been called once as second call result was cached
+      expect(testTooling.fetch).toHaveBeenCalledTimes(1);
+      expect(hasBeenImplementedAgain).toBeTrue();
+      expect(testTooling.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.toBeNonEmptyString(),
+          headers: expect.objectContaining({
+            Authorization: expect.toBeNonEmptyString(),
+            'Content-Type': expect.toBeNonEmptyString(),
+            'User-Agent': expect.toBeNonEmptyString(),
+            'X-Request-ID': expect.toBeNonEmptyString(),
+          }),
+          method: HTTP_METHOD.GET,
+        })
+      );
+    });
+
     test('getLambdas with filtering', async () => {
       expect.hasAssertions();
       await getLambdas({


### PR DESCRIPTION
FaaS and Controller Bot feature that allows users to set restrictions on which skill actions invoke their lambdas in a self-service manner.