### PR TITLE
:FC-921: :sparkles: Invocations by SkillId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveperson-functions-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript client for LivePerson Functions.",
   "author": {
     "name": "LivePersonInc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveperson-functions-client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "JavaScript client for LivePerson Functions.",
   "author": {
     "name": "LivePersonInc",

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -196,6 +196,7 @@ export class BaseClient {
 
     const query: BaseQuery = {
       v: invokeData.apiVersion,
+      skillId: data?.skillId,
       externalSystem: invokeData.externalSystem,
     };
     try {
@@ -499,6 +500,7 @@ export class BaseClient {
       ? {
           ...baseMetrics,
           event: data.eventId,
+          skillId: data?.skillId,
         }
       : {
           ...baseMetrics,

--- a/src/types/invocationTypes.ts
+++ b/src/types/invocationTypes.ts
@@ -18,6 +18,7 @@ export interface EventRequest {
   // setting specifying it with "| string" allows to the use of future event names that are not bundled
   // in the current typings
   readonly eventId: typeof EVENT[keyof typeof EVENT] | string;
+  readonly skillId?: string;
 }
 
 export interface FilterLambdas extends Partial<EventRequest> {

--- a/test/isImplementedCache.test.ts
+++ b/test/isImplementedCache.test.ts
@@ -37,7 +37,7 @@ describe('ImplementedCache', () => {
       expect(isImplementedCache.get(event,'sampleSkill')?.skillId).toBeString();
       expect(isImplementedCache.get(event,'sampleSkill')?.skillId).toEqual('sampleSkill');
     });
-    it('hould not return an undefined if no entry for provided skillId was found', () => {
+    it('should not return an undefined if no entry for provided skillId was found', () => {
       isImplementedCache.add(event, true,'skill');
 
       expect(isImplementedCache.get(event,'skillsample')).toBeUndefined();

--- a/test/unit/base_client.test.ts
+++ b/test/unit/base_client.test.ts
@@ -174,7 +174,7 @@ describe('Base Client', () => {
         eventId: EVENT.MessagingNewConversation,
         body: {payload: null},
         externalSystem: 'test',
-        skillId:'1234'
+        skillId: '1234',
       });
       expect(testTooling.metricCollector.onInvoke).toHaveBeenCalledTimes(1);
       expect(testTooling.metricCollector.onInvoke).toHaveBeenCalledWith(
@@ -183,12 +183,30 @@ describe('Base Client', () => {
           event: EVENT.MessagingNewConversation,
           externalSystem: 'test',
           fromCache: false,
-          skillId:'1234',
+          skillId: '1234',
           domain: 'test-domain.com',
         })
       );
     });
-
+    test('invoke method with eventId and no SkillId', async () => {
+      expect.hasAssertions();
+      await invoke({
+        eventId: EVENT.MessagingNewConversation,
+        body: {payload: null},
+        externalSystem: 'test',
+      });
+      expect(testTooling.metricCollector.onInvoke).toHaveBeenCalledTimes(1);
+      expect(testTooling.metricCollector.onInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: testConfig.accountId,
+          event: EVENT.MessagingNewConversation,
+          externalSystem: 'test',
+          fromCache: false,
+          skillId: undefined,
+          domain: 'test-domain.com',
+        })
+      );
+    });
     test('isImplemented method', async () => {
       expect.hasAssertions();
       const client = new BaseClient(testConfig, testTooling);
@@ -319,7 +337,7 @@ describe('Base Client', () => {
       const hasBeenImplemented = await client.isImplemented({
         eventId: EVENT.MessagingNewConversation,
         externalSystem: 'test',
-        skillId: 'skill'
+        skillId: 'skill',
       });
       expect(testTooling.metricCollector.onIsImplemented).toHaveBeenCalledTimes(
         1
@@ -341,7 +359,7 @@ describe('Base Client', () => {
       const hasBeenImplementedAgain = await client.isImplemented({
         eventId: EVENT.MessagingNewConversation,
         externalSystem: 'test',
-        skillId: 'skill'
+        skillId: 'skill',
       });
       // should still only have been called once as second call result was cached
       expect(testTooling.fetch).toHaveBeenCalledTimes(1);

--- a/test/unit/base_client.test.ts
+++ b/test/unit/base_client.test.ts
@@ -168,6 +168,26 @@ describe('Base Client', () => {
         externalSystem: 'test',
       });
     });
+    test('invoke method with eventId and SkillId', async () => {
+      expect.hasAssertions();
+      await invoke({
+        eventId: EVENT.MessagingNewConversation,
+        body: {payload: null},
+        externalSystem: 'test',
+        skillId:'1234'
+      });
+      expect(testTooling.metricCollector.onInvoke).toHaveBeenCalledTimes(1);
+      expect(testTooling.metricCollector.onInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: testConfig.accountId,
+          event: EVENT.MessagingNewConversation,
+          externalSystem: 'test',
+          fromCache: false,
+          skillId:'1234',
+          domain: 'test-domain.com',
+        })
+      );
+    });
 
     test('isImplemented method', async () => {
       expect.hasAssertions();


### PR DESCRIPTION
FaaS and Controller Bot feature that allows users to set restrictions on which skill actions invoke their lambdas in a self-service manner. This is phase two of the feature in which we allowing passing of skillId on invoke request